### PR TITLE
fix `from renardo_lib import *`

### DIFF
--- a/renardo_lib/renardo_lib/__init__.py
+++ b/renardo_lib/renardo_lib/__init__.py
@@ -1,0 +1,1 @@
+from renardo_lib.runtime import *


### PR DESCRIPTION
closes #26